### PR TITLE
Use hprof

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ cgmath = "*"
 gfx = "0.6.*"
 glutin = "*"
 gfx_window_glutin = "*"
+hprof = "0.1"
 
 [[example]]
 name = "alpha"

--- a/examples/beta/main.rs
+++ b/examples/beta/main.rs
@@ -5,6 +5,7 @@ extern crate gfx;
 extern crate gfx_window_glutin;
 extern crate gfx_phase;
 extern crate gfx_scene;
+extern crate hprof;
 
 mod app;
 
@@ -28,8 +29,17 @@ fn main() {
             }
         }
         
+        hprof::start_frame();
+        let g = hprof::enter("render");
         app.render(&mut stream);
+        drop(g);
 
+        let g = hprof::enter("present");
         stream.present(&mut device);
+        drop(g);
+        hprof::end_frame();
+
+        hprof::profiler().print_timing();
+
     }
 }

--- a/src/phase/Cargo.toml
+++ b/src/phase/Cargo.toml
@@ -16,3 +16,4 @@ path = "../queue"
 [dependencies]
 log = "*"
 gfx = "0.6.*"
+hprof = "0.1"

--- a/src/phase/lib.rs
+++ b/src/phase/lib.rs
@@ -7,6 +7,7 @@
 extern crate log;
 extern crate gfx;
 extern crate draw_queue;
+extern crate hprof;
 
 mod mem;
 mod phase;

--- a/src/scene/Cargo.toml
+++ b/src/scene/Cargo.toml
@@ -16,3 +16,4 @@ path = "../phase"
 [dependencies]
 cgmath = "*"
 gfx = "0.6.*"
+hprof = "0.1"

--- a/src/scene/lib.rs
+++ b/src/scene/lib.rs
@@ -5,6 +5,7 @@
 extern crate gfx_phase;
 extern crate gfx;
 extern crate cgmath;
+extern crate hprof;
 
 mod cull;
 


### PR DESCRIPTION
Example output:
```
  render - 81969ns (0.5054537503251235%)
    enqueue - 47000ns (57.33875001524966%)
    flush - 20557ns (25.078993277946545%)
      sort - 2050ns (9.972272218708955%)
      draw to stream - 14515ns (70.60855183149293%)
      clear - 2760ns (13.426083572505714%)
  present - 16131127ns (99.47100292941062%)
```

Fixes #31 

cc @cmr 