### PR TITLE
Remove ViewInfo from compile() parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_scene_meta"
-version = "0.0.4"
+version = "0.0.5"
 description = "Meta package for high-level rendering libraries on gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx_scene"
 keywords = ["graphics", "gamedev"]
@@ -21,7 +21,7 @@ path = "src/scene"
 
 [dev_dependencies]
 cgmath = "*"
-gfx = "0.6.*"
+gfx = "0.6"
 glutin = "*"
 gfx_window_glutin = "*"
 hprof = "0.1"

--- a/examples/alpha/app.rs
+++ b/examples/alpha/app.rs
@@ -88,11 +88,11 @@ for Technique<R> {
         Some(mat.alpha < 1.0)
     }
 
-    fn compile<'a>(&'a self, kernel: bool, space: &ViewInfo)
-                   -> gfx_phase::TechResult<'a, R, Params<R>> {
+    fn compile<'a>(&'a self, kernel: bool)
+               -> gfx_phase::TechResult<'a, R, Params<R>> {
         (   &self.program,
             Params {
-                transform: space.0.into_fixed(),
+                transform: [[0.0; 4]; 4],
                 color: [0.4, 0.5, 0.6, 0.0],
                 _r: PhantomData,
             },

--- a/examples/beta/app.rs
+++ b/examples/beta/app.rs
@@ -83,9 +83,7 @@ for Technique<R> {
         Some(())
     }
 
-    fn compile<'a>(&'a self, _: (), _: &ViewInfo)
-               -> gfx_phase::TechResult<'a, R, Params<R>>
-    {
+    fn compile<'a>(&'a self, _: ()) -> gfx_phase::TechResult<'a, R, Params<R>> {
         (   &self.program,
             Params {
                 offset: [0.0; 2],

--- a/src/phase/Cargo.toml
+++ b/src/phase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_phase"
-version = "0.3.0"
+version = "0.4.0"
 description = "Render phase abstraction for gfx-rs"
 license = "Apache-2.0"
 authors = ["The Gfx-rs Developers"]
@@ -11,9 +11,9 @@ path = "lib.rs"
 
 [dependencies.draw_queue]
 path = "../queue"
-#version = "*"
+version = "0.1"
 
 [dependencies]
 log = "*"
-gfx = "0.6.*"
+gfx = "0.6"
 hprof = "0.1"

--- a/src/phase/lib.rs
+++ b/src/phase/lib.rs
@@ -50,9 +50,10 @@ pub trait Technique<R: gfx::Resources, M: Material, V: ToDepth> {
     /// Test if this mesh/material can be drawn using the technique.
     fn test(&self, &gfx::Mesh<R>, &M) -> Option<Self::Kernel>;
     /// Compile a given kernel by producing a program, parameter block,
-    /// a draw state, and an optional instancing data.
-    fn compile<'a>(&'a self, Self::Kernel, &V)
+    /// a draw state, and optional instancing data.
+    fn compile<'a>(&'a self, Self::Kernel)
                    -> TechResult<'a, R, Self::Params>;
     /// Fix the shader parameters, using an updated material and view info.
+    /// Called every time before a batch is added to the draw queue.
     fn fix_params(&self, &M, &V, &mut Self::Params);
 }

--- a/src/phase/phase.rs
+++ b/src/phase/phase.rs
@@ -238,7 +238,7 @@ impl<
         }
         // Compile with the technique
         let (program, mut params, state, instancing) =
-            self.technique.compile(kernel, view_info);
+            self.technique.compile(kernel);
         self.technique.fix_params(material, view_info, &mut params);
         let mut temp_mesh = gfx::Mesh::new(orig_mesh.num_vertices);
         let (instances, mesh) = match instancing {
@@ -302,7 +302,7 @@ impl<
         }
 
         // done
-        let g = hprof::enter("clear");
+        let _g = hprof::enter("clear");
         self.queue.objects.clear();
         Ok(())
     }

--- a/src/scene/Cargo.toml
+++ b/src/scene/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_scene"
-version = "0.3.0"
+version = "0.4.0"
 description = "Space-aware scene rendering and culling"
 license = "Apache-2.0"
 authors = ["The Gfx-rs Developers"]
@@ -11,9 +11,9 @@ path = "lib.rs"
 
 [dependencies.gfx_phase]
 path = "../phase"
-#version = "*"
+version = "0.4"
 
 [dependencies]
 cgmath = "*"
-gfx = "0.6.*"
+gfx = "0.6"
 hprof = "0.1"


### PR DESCRIPTION
Conceptually, `ViewInfo` is something provided by the higher-level code (a pipeline, for example), containing spatial/view information. This data can be changed any frame at will. No need to provide it as an argument to `Technique::compile()`.