### PR TITLE
Update travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: rust
 rust:
+  - 1.0.0
+  - stable
+  - beta
   - nightly
-  - 1.0.0-beta.4
 env:
   global:
     - LD_LIBRARY_PATH: /usr/local/lib


### PR DESCRIPTION
I'm not sure if you'd want the `1.0.0` entry, but since you had `1.0.0-beta.4` there I added it just in case that's something you want to assure as well. This will now test on 1.0.0, the latest stable, the latest beta and the latest nightly.